### PR TITLE
Add privacy policy for US Citizenship Test App

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - US Citizenship Test App</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            color: #333;
+        }
+        h1 {
+            color: #2C3E50;
+            border-bottom: 2px solid #3498DB;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #34495E;
+            margin-top: 30px;
+        }
+        .contact-info {
+            background-color: #f8f9fa;
+            padding: 15px;
+            border-radius: 8px;
+            margin-top: 30px;
+        }
+        .highlight {
+            background-color: #e8f4f8;
+            padding: 15px;
+            border-left: 4px solid #3498DB;
+            margin: 20px 0;
+        }
+        ul {
+            padding-left: 20px;
+        }
+        li {
+            margin-bottom: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Privacy Policy for US Citizenship Test App</h1>
+    
+    <div class="highlight">
+        <strong>Effective Date:</strong> December 2024<br>
+        <strong>Last Updated:</strong> December 2024
+    </div>
+
+    <h2>Overview</h2>
+    <p>The US Citizenship Test App ("we", "our", or "us") is committed to protecting your privacy. This privacy policy explains how we handle information in our mobile application that helps users study for the US citizenship test.</p>
+
+    <h2>Information We Collect and Store</h2>
+    <p>Our app stores the following information <strong>locally on your device only</strong>:</p>
+    <ul>
+        <li><strong>Personal Study Preferences:</strong> Your selected state, senators, representative, and governor</li>
+        <li><strong>Study Progress:</strong> Questions you've marked as favorites</li>
+        <li><strong>App Settings:</strong> Display preferences (such as showing/hiding categories)</li>
+        <li><strong>Usage Data:</strong> Your current position in the question set and study progress</li>
+    </ul>
+
+    <div class="highlight">
+        <strong>Important:</strong> All data is stored locally on your device. We do not collect, transmit, or store any personal information on external servers.
+    </div>
+
+    <h2>How We Use Your Information</h2>
+    <p>The locally stored information is used to:</p>
+    <ul>
+        <li>Provide personalized study content based on your state</li>
+        <li>Display your local representatives in relevant citizenship questions</li>
+        <li>Remember your favorite questions and study progress</li>
+        <li>Maintain your app preferences between sessions</li>
+        <li>Enhance your overall study experience</li>
+    </ul>
+
+    <h2>Data Storage and Security</h2>
+    <ul>
+        <li><strong>Local Storage Only:</strong> All your data is stored locally on your device using secure iOS storage mechanisms</li>
+        <li><strong>No Data Transmission:</strong> We do not send your personal information to any external servers</li>
+        <li><strong>No Account Required:</strong> The app works completely offline and doesn't require registration</li>
+        <li><strong>Data Deletion:</strong> All your data is automatically deleted when you uninstall the app</li>
+    </ul>
+
+    <h2>Third-Party Services</h2>
+    <p>Our app:</p>
+    <ul>
+        <li>Does not use third-party analytics services</li>
+        <li>Does not use advertising networks</li>
+        <li>Does not use crash reporting services that collect personal data</li>
+        <li>May fetch citizenship questions from our public GitHub repository (no personal data is sent)</li>
+    </ul>
+
+    <h2>Children's Privacy</h2>
+    <p>Our app does not knowingly collect personal information from children under the age of 13. The app is designed to help individuals study for the US citizenship test and is intended for users who are eligible to take the citizenship test.</p>
+
+    <h2>Your Rights and Choices</h2>
+    <p>Since all data is stored locally on your device, you have complete control:</p>
+    <ul>
+        <li><strong>Access:</strong> You can view all your data within the app's settings</li>
+        <li><strong>Modify:</strong> You can change or delete any information through the app interface</li>
+        <li><strong>Delete:</strong> You can clear all data by uninstalling the app</li>
+    </ul>
+
+    <h2>Changes to This Privacy Policy</h2>
+    <p>We may update this privacy policy from time to time. Any changes will be posted on this page with an updated "Last Updated" date. We encourage you to review this privacy policy periodically.</p>
+
+    <h2>Disclaimer</h2>
+    <p>This app is not affiliated with, endorsed by, or connected to the U.S. Citizenship and Immigration Services (USCIS) or any other government agency. The citizenship test questions are based on publicly available information and are for study purposes only.</p>
+
+    <div class="contact-info">
+        <h2>Contact Us</h2>
+        <p>If you have any questions about this privacy policy or our data practices, please contact us:</p>
+        <p>
+            <strong>Email:</strong> [YOUR-EMAIL@DOMAIN.COM]<br>
+            <strong>App Store:</strong> Search for "US Citizenship Test App"
+        </p>
+        <p><em>Please replace the email address above with your actual contact email before publishing.</em></p>
+    </div>
+
+    <hr style="margin: 40px 0; border: none; border-top: 1px solid #ddd;">
+    <p style="text-align: center; color: #666; font-size: 14px;">
+        © 2024 US Citizenship Test App. This privacy policy was last updated on December 2024.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
- Created comprehensive privacy policy for App Store submission
- Covers local data storage, no external data transmission
- Includes all required sections for iOS app compliance
- Ready for GitHub Pages hosting

🤖 Generated with [Claude Code](https://claude.ai/code)